### PR TITLE
Fixed typo in facebook.yml.sample

### DIFF
--- a/sample_config/facebook.yml.sample
+++ b/sample_config/facebook.yml.sample
@@ -6,6 +6,6 @@ test:
   app_id: 'abcxyz'
   secret_key: 'abcxyz'
 
-producttion:
+production:
   app_id: 'abcxyz'
   secret_key: 'abcxyz'


### PR DESCRIPTION
This typo causes a cryptic error.
