### PR TITLE
Skip email confirmation of seed user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,6 +23,8 @@ if User.count == 0
                        password: "supersecretpass",
                        password_confirmation: "supersecretpass",
                        system_role_id: super_role.id)
+  admin.skip_confirmation!
+  admin.save!
 end
 
 if Action.count == 0


### PR DESCRIPTION
I shouldn't have to hack my database to activate my seed user.
