### PR TITLE
Fix safari code background bug

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -899,19 +899,6 @@ $grayMediumLight: #eaeaea;
 .checkbox-text {
   padding-top: 5px;
 }
-.checkbox-text label {
-  display: inline-table;
-  //padding-left: 5px;
-  max-width: 90%;
-  //text-indent: -15px;
-}
-
-.checkbox-text span {
-  padding-left: 7px;
-  //text-indent: -15px;
-  display: inline-table;
-  max-width: 90%;
-}
 
 .checkbox-text input {
   //width: 13px;


### PR DESCRIPTION
I did not try to fix the overflow issue as it's quite nasty to fix it when spans and divs are nested in the table in trainings/show.html.erb. We can try to fix it when we've ported to bootstrap 3.
