### PR TITLE
Fix missing attach_files method on Assessment::Training. Move method to parent class

### DIFF
--- a/app/models/assessment/assessment.rb
+++ b/app/models/assessment/assessment.rb
@@ -289,4 +289,14 @@ class Assessment < ActiveRecord::Base
     asm.as_assessment = d
     asm
   end
+
+  def attach_files(files)
+    files.each do |id|
+      file = FileUpload.find id
+      if file
+        file.owner = self
+        file.save
+      end
+    end
+  end
 end

--- a/app/models/assessment/mission.rb
+++ b/app/models/assessment/mission.rb
@@ -17,16 +17,6 @@ class Assessment::Mission < ActiveRecord::Base
     "#{I18n.t('Assessment.Mission')} : #{self.title}"
   end
 
-  def attach_files(files)
-    files.each do |id|
-      file = FileUpload.where(id: id).first
-      if file
-        file.owner = self
-        file.save
-      end
-    end
-  end
-
   def total_exp
     exp
   end


### PR DESCRIPTION
![lol](http://i.imgur.com/hy6vDb1.gif)

Creating a new training with files attached will trigger undefined method `attach_files' on an instance of Assessment::Training. This PR fixes it. :smile:
