### PR TITLE
fixed missing github link for coursemology team

### DIFF
--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -147,7 +147,7 @@
 									<img src="http://www.gravatar.com/avatar/49a3e4d86a545a922407b3c6a124a38e?s=70" class="about_profile_pic">
 								</a>
 								<br>
-								<a href="/#" target="_blank">
+								<a href="https://github.com/BenMQ" target="_blank">
 									<i class="icon-github icon-2x"></i>
 								</a>
 							</div>


### PR DESCRIPTION
Left out one github link. 
