### PR TITLE
Fixing bonus exp bug

### DIFF
--- a/app/models/assessment/grading.rb
+++ b/app/models/assessment/grading.rb
@@ -51,7 +51,9 @@ class Assessment::Grading < ActiveRecord::Base
       self.exp_transaction.exp *= submission.multiplier
     end
 
-    self.exp_transaction.exp += submission.get_bonus
+    if self.submission.done?
+      self.exp_transaction.exp += submission.get_bonus
+    end
     self.exp_transaction.save
   end
 


### PR DESCRIPTION
Our last fix is not totally correct, student will immediately get the bonus exp once they attend the training.
