### PR TITLE
Revert "Request publish_actions in devise.rb sample initializer file"

### DIFF
--- a/sample_config/devise_initializer.rb.sample
+++ b/sample_config/devise_initializer.rb.sample
@@ -206,7 +206,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
-  config.omniauth :facebook, "sdf", 'asdf', { :scope => "publish_actions" }
+  config.omniauth :facebook, "sdf", 'asdf'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
The permission should only be requested when the user wants to publish something to Facebook and not on initial login.
