### PR TITLE
Question number starts from 1 instead of 0.

### DIFF
--- a/app/models/assessment/question.rb
+++ b/app/models/assessment/question.rb
@@ -23,7 +23,7 @@ class Assessment::Question < ActiveRecord::Base
 
   #TOFIX
   def get_title
-    title && !title.empty? ? title : "Question #{question_assessments.first.position}"
+    title && !title.empty? ? title : "Question #{question_assessments.first.position + 1}"
   end
 
   #callback methods


### PR DESCRIPTION
When a question doesn't have a title, the get_title method will return 'Question' together with the position of the first QuestionAssessment. That position starts counting from 0, which makes question title look weird to people without programming background. Change it to start counting from 1 instead.
