### PR TITLE
Using rake script to fix exsiting grading errors

### DIFF
--- a/lib/tasks/training.rake
+++ b/lib/tasks/training.rake
@@ -40,7 +40,7 @@ namespace :training do
 
   def mcq_grader(submission, ans, mcq, pref_grader, ag)
     std_answers = submission.answers.where(question_id: ans.question_id).order(created_at: :asc)
-    if pref_grader != 'two-one-zero' || std_answers.first.correct
+    if std_answers.first.correct
       ag.grade = mcq.max_grade
     else
       num_wrong_choices = mcq.options.find_all_by_correct(false).count


### PR DESCRIPTION
We need to fix course Hai Siang and Yanjie's course using this script.

If a course is using TOZ grader, the script will re grade all the training submission mcq questions and update the grade.

Usage:
Fix course 99:
rake training: re_grading_mcq[99]
