### PR TITLE
Fix a bug of "run-button not responding when there were any errors."

### DIFF
--- a/app/assets/javascripts/mission_submissions.js
+++ b/app/assets/javascripts/mission_submissions.js
@@ -20,7 +20,7 @@ codeEvaluator = function () {
     return {
         testRun: function (ans_id, url, btn) {
             if (self.running) return;
-            
+
             self.running = true;
             var index = self.ans_ids.indexOf(ans_id);
             var code = self.cvs[index].editor.getValue();


### PR DESCRIPTION
In mission submission, after clicking run. If there were any errors, then you cannot click run button any more.
