### PR TITLE
Fix level/ achievement display twice bug

### DIFF
--- a/app/models/assessment/grading.rb
+++ b/app/models/assessment/grading.rb
@@ -38,6 +38,7 @@ class Assessment::Grading < ActiveRecord::Base
 
   def update_exp_transaction
     asm = submission.assessment
+
     unless self.exp_transaction
       exp_transaction = ExpTransaction.create({ giver_id: self.grader_id,
                                                     user_course_id: submission.std_course_id,
@@ -58,6 +59,9 @@ class Assessment::Grading < ActiveRecord::Base
     if self.submission.done?
       self.exp_transaction.exp += submission.get_bonus
     end
+
+    # this handles the case where grade is changed, but exp is not changed.
+    # we don't want to call update_exp_and_level_async twice
     exp_create_or_changed ||= self.exp_transaction.exp_changed?
     self.exp_transaction.save
 


### PR DESCRIPTION
There is a save function in update_exp_transaction, I changed to update_column, so it will not triggle after_save callback.
