### PR TITLE
add a parse string function to enable #<> in code editor

### DIFF
--- a/app/assets/javascripts/code.js
+++ b/app/assets/javascripts/code.js
@@ -207,22 +207,11 @@ function CodeViewer($wrapper, source, theme, code_id, sub_id, _vt, language){
             });
         return $lines;
     }
-    function parseCommentString(string){
+    function sanctifyCommentsHtmlTags(string){
         if(string.charAt(0) != '#') {
             return string;
         }
-        var stringParsed = '';
-        for ( var i = 0; i < string.length; i++ ){
-            var c = string.charAt(i);
-            if(c == '<'){
-                stringParsed += "<span class=\"cm-comment\"><</span>";
-            } else if (c == '>') {
-                stringParsed += "<span class=\"cm-comment\">></span>";
-            } else {
-                stringParsed += c;
-            }
-        };
-        return stringParsed;
+        return string.replace(/(>|<)/g, "<span class=\"cm-comment\">$1</span>");
     };
     var $active = false;
     function activateComment($com) {
@@ -506,7 +495,7 @@ function CodeViewer($wrapper, source, theme, code_id, sub_id, _vt, language){
                 zam.push('<pre class="line">'+str+"\n"+'</pre>');
                 accum = [];
             }else if (style){
-                string = parseCommentString(string);
+                string = sanctifyCommentsHtmlTags(string);
                 accum.push("<span class=\"cm-" + style + "\">" + string + "</span>");
             }else{
                 accum.push(string);


### PR DESCRIPTION
Now the code like "# '<' tag '>' '<' tag '>'" in code editor will disappear after submission.

This issue is important because students are using comment to answers questions.

By default, Codemirror will not decorate comment part. Fixed this by pre-parse the comment part, and change '<'  in comments to '<'span'>' < '<'/span'>'
