### PR TITLE
Fix assessment max grade nil bug

### DIFF
--- a/app/models/asm_req.rb
+++ b/app/models/asm_req.rb
@@ -16,7 +16,7 @@ class AsmReq < ActiveRecord::Base
 
     if last_sbm
       final_grading = last_sbm.get_final_grading
-      if final_grading
+      if final_grading && asm.max_grade
         return ((final_grading.grade || 0) * 100 / asm.max_grade) >= min_grade - EPS
       end
     end


### PR DESCRIPTION
Fix this bug in achievement: nil can't be coerced into Fixnum
