### PR TITLE
Bugfix for html editor

### DIFF
--- a/app/assets/javascripts/html_editor.js
+++ b/app/assets/javascripts/html_editor.js
@@ -170,14 +170,14 @@ $(document).ready(function() {
   // setup html editor
   var options = $.extend(true, {}, $.fn.wysihtml5.defaultOptions);
   options.parserRules.classes['coursemology-code'] = 1;
-  options.parserRules.tags['sub'] = 1;
-  options.parserRules.tags['sup'] = 1;
-  options.parserRules.tags['iframe'] = {
+  options.parserRules.tags.sub = 1;
+  options.parserRules.tags.sup = 1;
+  options.parserRules.tags.iframe = {
     "check_attributes": {
       "width": "numbers",
       "alt": "alt",
       "src": "url",
-      "src2": "url", 
+      "src2": "url",
       "height": "numbers",
     },
     "set_attributes": {


### PR DESCRIPTION
Thanks to @wangqiang1208 for spotting the bug!

The bug was that only sub/sup/iframe tags work. bold italics etc tags are cleaned from the code.
