### PR TITLE
do not display count icon when there is no role request

### DIFF
--- a/app/views/layouts/_admin_side_bar.erb
+++ b/app/views/layouts/_admin_side_bar.erb
@@ -11,7 +11,7 @@
     <li><%= link_to "Masquerade", admin_masquerades_path %></li>
     <li>
       <a href="<%= role_requests_path %>">
-        Role Requests <span class="sidenav-count " ><%= @request_count if @request_count && @request_count > 0  %></span>
+        Role Requests <% if @request_count && @request_count > 0 %><span class="sidenav-count " ><%= @request_count %></span><% end %>
       </a>
     </li>
     <li><%= link_to "Courses", admin_courses_path %></li>


### PR DESCRIPTION
![screen shot 2014-10-17 at 12 03 43 am](https://cloud.githubusercontent.com/assets/4983239/4665841/12fc2d26-554e-11e4-99e9-cb25e35ab831.png)

The sidebar count icon still appear when there is no role request.

Fixed by put icon span inside if statement.
