### PR TITLE
Add sys and traceback to sandbox's whitelisted modules.

### DIFF
--- a/python/sandbox/cos_sandbox.py
+++ b/python/sandbox/cos_sandbox.py
@@ -73,7 +73,7 @@ ALLOWED_STDLIB_MODULE_IMPORTS = ('math', 'random', 'datetime',
 													'functools', 'itertools', 'operator', 'string',
 													'collections', 're', 'json', 'csv','copy','copyreg',
 													'engine','hungry_games_classes','hungry_games','simulation',
-													'heapq', 'bisect','inspect','__future__', 'generic_arith_min', 'encodings.idna', 'encodings', 'urllib', 'urllib.error', 'buses')
+													'heapq', 'bisect','inspect','__future__', 'generic_arith_min', 'encodings.idna', 'encodings', 'urllib', 'urllib.error', 'buses', 'sys', 'traceback')
 
 # whitelist of custom modules to import into OPT
 # (TODO: support modules in a subdirectory, but there are various


### PR DESCRIPTION
I hope whitelisting these two modules is allowed.
