### PR TITLE
Whitelist uuid

### DIFF
--- a/python/sandbox/cos_sandbox.py
+++ b/python/sandbox/cos_sandbox.py
@@ -73,7 +73,7 @@ ALLOWED_STDLIB_MODULE_IMPORTS = ('math', 'random', 'datetime',
 													'functools', 'itertools', 'operator', 'string',
 													'collections', 're', 'json', 'csv','copy','copyreg',
 													'engine','hungry_games_classes','hungry_games','simulation',
-													'heapq', 'bisect','inspect','__future__', 'generic_arith_min', 'encodings.idna', 'encodings', 'urllib', 'urllib.error', 'buses', 'uuid')
+													'heapq', 'bisect','inspect','__future__', 'generic_arith_min', 'encodings.idna', 'encodings', 'urllib', 'urllib.error', 'buses', 'uuid', 'vars')
 
 # whitelist of custom modules to import into OPT
 # (TODO: support modules in a subdirectory, but there are various


### PR DESCRIPTION
Mission 15's hungry_game_classes module imports the uuid module and uses vars.
