### PR TITLE
Unblock the vars function in the whitelist

### DIFF
--- a/python/sandbox/cos_sandbox.py
+++ b/python/sandbox/cos_sandbox.py
@@ -73,7 +73,7 @@ ALLOWED_STDLIB_MODULE_IMPORTS = ('math', 'random', 'datetime',
 													'functools', 'itertools', 'operator', 'string',
 													'collections', 're', 'json', 'csv','copy','copyreg',
 													'engine','hungry_games_classes','hungry_games','simulation',
-													'heapq', 'bisect','inspect','__future__', 'generic_arith_min', 'encodings.idna', 'encodings', 'urllib', 'urllib.error', 'buses', 'uuid', 'vars')
+													'heapq', 'bisect','inspect','__future__', 'generic_arith_min', 'encodings.idna', 'encodings', 'urllib', 'urllib.error', 'buses', 'uuid')
 
 # whitelist of custom modules to import into OPT
 # (TODO: support modules in a subdirectory, but there are various
@@ -159,7 +159,7 @@ def sandbox():
 
 	BANNED_BUILTINS = ['reload', 'compile',
 										'file', 'eval', 'exec', 'execfile',
-										'exit', 'quit', 'help','globals', 'locals', 'vars']
+										'exit', 'quit', 'help','globals', 'locals']
 
 	if type(__builtins__) is dict:
 		builtin_items = __builtins__.items()


### PR DESCRIPTION
The earlier pull request #256 by @DIdiHL does not unlock the `vars` function properly. This pull requests fixes that, and enables the `vars` function.

PS: Is there any security issue that might happen by allowing the `vars` function?

@raymondtangsc 
