### PR TITLE
rescue seen_by_users record unique exception caused by threadsafe

### DIFF
--- a/app/models/user_course.rb
+++ b/app/models/user_course.rb
@@ -315,7 +315,11 @@ class UserCourse < ActiveRecord::Base
         s = self.seen_stuff.build()
         s.obj_type = objs[0].class.to_s
         s.obj_id = obj
-        s.save
+        # we do have thread safe issues here, since the record is unique, we can ignore the exception
+        begin
+          s.save
+        rescue ActiveRecord::RecordNotUnique
+        end
       end
     end
   end


### PR DESCRIPTION
This issue cannot be totally solved unless re-desgin. we also cannot use locks here because the requests are handled by different processes on server ( not threads).
