### PR TITLE
fix for "nil can't be coerced into Float"

### DIFF
--- a/app/models/assessment/grading.rb
+++ b/app/models/assessment/grading.rb
@@ -51,7 +51,7 @@ class Assessment::Grading < ActiveRecord::Base
       update_column(:exp_transaction_id, exp_transaction.id)
     end
 
-    self.exp_transaction.exp = self.exp || (self.grade || 0) * asm.exp / asm.max_grade
+    self.exp_transaction.exp = exp || (grade || 0) * asm.exp / (asm.max_grade || 1)
     if submission.has_multiplier?
       self.exp_transaction.exp *= submission.multiplier
     end


### PR DESCRIPTION
asm.max_grade is nil when there is no question in the assessment
