### PR TITLE
Survey reset

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -65,7 +65,14 @@ class SurveysController < ApplicationController
     @std_courses = @course.user_courses.student.order(:name).where(is_phantom: false)
     @std_courses_phantom = @course.user_courses.student.order(:name).where(is_phantom: true)
   end
-
+  
+  def reset
+    SurveySubmission.where(survey_id: params[:id]).destroy_all
+    respond_to do |format|
+        format.html { redirect_to(course_survey_stats_path(@course, @survey), notice: 'Survey has been reset successfully') }  
+    end
+  end
+  
   def summary
     @tab = params[:_tab]
     include_phantom = @tab == "summary_phantom"

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -3,6 +3,9 @@
 </div>
 
 <%= render partial: "nav_bar" %>
+<div class="col-sm-offset-10 col-sm-2" >
+<%= button_to "Reset Survey", {action: 'reset'}, class:'btn-danger', data:{ confirm: 'All responded answers will be removed. Are you sure to continue?', disable_with: 'Loading..' }  %>
+</div>
 <% no_qn = @survey.survey_questions.count %>
 <% [@staff_courses, @std_courses, @std_courses_phantom].each_with_index do |user_courses, index| %>
     <% case index  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Coursemology::Application.routes.draw do
     match "surveys/:id/stats" => "surveys#stats", as: :survey_stats
     match "surveys/:id/summary" => "surveys#summary", as: :survey_summary
     match "surveys/:id/summary_with_format" => "surveys#summary_with_format", as: :survey_summary_with_format
+    post "surveys/:id/reset" => "surveys#reset", as: :survey_stats_reset
 
     get "lesson_plan" => 'lesson_plan_entries#index', as: :lesson_plan
     get "lesson_plan/overview" => 'lesson_plan_entries#overview', as: :lesson_plan_overview


### PR DESCRIPTION
Reset Survey:
=============
Affected files: 
1) config/routes
     Add: 
   <code> post "surveys/:id/reset" => "surveys#reset", as: :survey_stats_reset</code>

2) app/controllers/surveys_controller
  Add Action:
 <code> 
def reset
</code>
    <code>SurveySubmission.where(survey_id: params[:id]).destroy_all</code>
    <code>respond_to do |format| </code> 
     <code>   format.html { redirect_to(course_survey_stats_path(@course, @survey), notice: 'Survey has been reset successfully') }  </code>
    <code>end</code>
 <code> end</code>


3) app/views/surveys/stats.html.erb
  Add Reset buttton:
<code>
    <div class="col-sm-offset-10 col-sm-2" >
<%= button_to "Reset Survey", {action: 'reset'}, class:'btn-danger', data:{ confirm: 'All responded answers will be removed. Are you sure to continue?', disable_with: 'Loading..' }  %>
</div>
</code>

Feature: Lecturer is able to reset his/her survey. Once he reset all the answers will be destroyed. Users are required to do survey again. 

Fixed : https://github.com/Coursemology/coursemology.org/issues/140