### PR TITLE
change html_editor's upload_path to file_uploads_path

### DIFF
--- a/app/views/layouts/_html_editor.html.erb
+++ b/app/views/layouts/_html_editor.html.erb
@@ -3,7 +3,7 @@
     <%= render partial: "layouts/image_uploader",
                locals: { container_class: "bootstrap-wysihtml5-insert-image-modal",
                          image_url_class: "bootstrap-wysihtml5-insert-image-url",
-                         upload_to: course_file_uploads_path(@course) } %>
+                         upload_to: file_uploads_path } %>
     <a class="btn" data-wysihtml5-command="insertImage"><i class="icon-picture"></i></a>
   </li>
 </div>


### PR DESCRIPTION
1. Now students cannot upload images to forum due to permission issues.
2. I changed html_editor's upload url to 'file_upload_path' instead of 'course_file_upload_path', thus users will be able to upload images through html editor.

BTW, To make sure that I'm doing the correct thing, I think course_file_uploads_path is for materials( not images)?  for this path we will check permissions.
