### PR TITLE
highlighting actual output instead of expected output

### DIFF
--- a/app/views/assessment/mission_submissions/_test_result_table.html.erb
+++ b/app/views/assessment/mission_submissions/_test_result_table.html.erb
@@ -11,10 +11,10 @@
   <% tests.each_with_index do |test, index| %>
       <tr>
         <td><%= test["expression"] %></td>
-        <td style="<%=  (!results.nil? && (results.length > index and results[index])) ? 'background-color: rgb(0, 128, 0);' : 'background-color: rgb(225, 193, 177);' %>">
+        <td>
           <%= test["expected"] %>
         </td>
-        <td>
+        <td style="<%=  (!results.nil? && (results.length > index and results[index])) ? 'background-color: rgb(0, 128, 0);' : 'background-color: rgb(225, 193, 177);' %>">
           <!--limit display of result-->
           <%= actual[index][0..200] if actual and actual[index] %>
         </td>


### PR DESCRIPTION
A stuff was complaining that highlighting output on the left side (expected result) is mis-leading.  So I did some change.
Before:
![screen shot 2014-11-18 at 10 13 16 pm](https://cloud.githubusercontent.com/assets/4983239/5088624/45f61ea8-6f70-11e4-91e8-af8fa6df887f.png)

Now:
![screen shot 2014-11-18 at 10 14 01 pm](https://cloud.githubusercontent.com/assets/4983239/5088627/4bd54c86-6f70-11e4-934f-589c1152ce13.png)
