### PR TITLE
Use travis' container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
See http://docs.travis-ci.com/user/workers/container-based-infrastructure/

By using their container infrastructure, open source repositories like ours can use `bundler: cache` and speed up builds!
