### PR TITLE
change display time of average time in staff leaderboard when there's no grading

### DIFF
--- a/app/views/staff_leaderboard/monitoring.html.erb
+++ b/app/views/staff_leaderboard/monitoring.html.erb
@@ -54,8 +54,8 @@
         <td style="text-align: left"><%= tutor.name %></td>
         <td><a href="<%= course_staff_monitoring_path %>?_tutor_id=<%=tutor.id%>"><%= summary[:count] %> </a></td>
         <td><%= summary[:std_count] %></td>
-        <td><%= summary[:avg] != Float::INFINITY ? distance_of_time(summary[:avg].to_i) : "99 d 99:99:99" %></td>
-        <td><%= summary[:std_dev] != Float::INFINITY ? distance_of_time(summary[:std_dev].to_i) : "99 d 99:99:99" %></td>
+        <td><%= summary[:avg] != Float::INFINITY ? distance_of_time(summary[:avg].to_i) : "--:--:--" %></td>
+        <td><%= summary[:std_dev] != Float::INFINITY ? distance_of_time(summary[:std_dev].to_i) : "--:--:--" %></td>
       </tr>
   <% end %>
   </tbody>


### PR DESCRIPTION
change 99:99:99 to --:--:--

Before:
![screen shot 2014-12-30 at 11 40 22 am](https://cloud.githubusercontent.com/assets/4983239/5575487/12577e92-9019-11e4-9d92-e792f8fa7090.png)

Now:
![screen shot 2014-12-30 at 11 38 17 am](https://cloud.githubusercontent.com/assets/4983239/5575488/198c31b2-9019-11e4-8790-7fc97f100346.png)
