### PR TITLE
Fix duplicate achievements in course activities

### DIFF
--- a/app/models/survey_submission.rb
+++ b/app/models/survey_submission.rb
@@ -40,7 +40,6 @@ class SurveySubmission < ActiveRecord::Base
       self.exp_transaction.exp = survey.exp
       self.exp_transaction.rewardable = survey
       self.save
-      self.exp_transaction.update_user_data
     end
 
     self.status = 'submitted'


### PR DESCRIPTION
<code>update_user_data</code>  was called twice after survey submitted, which caused the bug.

Fixed by removing one of them, it will automatically be called after <code>exp_transaction</code> is saved.