### PR TITLE
Fix invalid call to wicked_pdf_stylesheet_link_tag

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -18,6 +18,5 @@
  //= require codemirror
  //= require codemirror/themes/night
  *= require_tree .
- *= stub pdf
  */
 

--- a/app/views/assessment/gradings/show.pdf.erb
+++ b/app/views/assessment/gradings/show.pdf.erb
@@ -4,8 +4,7 @@
   <title>Coursemology</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/images/favicon.png">
-  <%= wicked_pdf_stylesheet_link_tag "application", :media => "all" %>
-  <%= wicked_pdf_stylesheet_link_tag "pdf", :media => "all" %>
+  <%= wicked_pdf_stylesheet_link_tag "application" %>
 </head>
 <body class="pdfbody">
 

--- a/app/views/assessment/training_submissions/show.pdf.erb
+++ b/app/views/assessment/training_submissions/show.pdf.erb
@@ -4,8 +4,7 @@
   <title>Coursemology</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/images/favicon.png">
-  <%= wicked_pdf_stylesheet_link_tag "application", :media => "all" %>
-  <%= wicked_pdf_stylesheet_link_tag "pdf", :media => "all" %>
+  <%= wicked_pdf_stylesheet_link_tag "application" %>
 </head>
 <body class="pdfbody">
 


### PR DESCRIPTION
Resolves the `{:media=>"all"}.css isn't precompiled` error in production environments.

This PR also adds `pdf.css.scss` to the asset pipeline, so assets will need to be recompiled upon deployment.