### PR TITLE
Fix #338. Skip assigning of mean and std dev when time_diff is empty.

### DIFF
--- a/app/controllers/staff_leaderboard_controller.rb
+++ b/app/controllers/staff_leaderboard_controller.rb
@@ -42,10 +42,8 @@ class StaffLeaderboardController < ApplicationController
       @summaries[tutor.id] = summary
       gradings = tutor.gradings.includes(:submission).order(:created_at)
       @summaries[tutor.id][:std_count] = tutor.std_courses.where(is_phantom: false).count
-      if gradings.count == 0
-        next
-      end
       time_diff = gradings.reduce([]) { |acc, g| (g.created_at - g.submission.submitted_at > 0) ? (acc << g.created_at - g.submission.submitted_at) : acc }
+      next if time_diff.empty?
       avg = time_diff.mean
       std_dev = time_diff.standard_deviation
       summary[:count] = gradings.length

--- a/app/controllers/staff_leaderboard_controller.rb
+++ b/app/controllers/staff_leaderboard_controller.rb
@@ -38,9 +38,9 @@ class StaffLeaderboardController < ApplicationController
 
     @summaries = {}
     @tutors.each do |tutor|
-      summary = {count: 0, avg: Float::INFINITY, std_dev: Float::INFINITY }
-      @summaries[tutor.id] = summary
       gradings = tutor.gradings.includes(:submission).order(:created_at)
+      summary = { count: gradings.length, avg: Float::INFINITY, std_dev: Float::INFINITY }
+      @summaries[tutor.id] = summary
       @summaries[tutor.id][:std_count] = tutor.std_courses.where(is_phantom: false).count
       time_diff = gradings.reduce([]) { |acc, g| (g.created_at - g.submission.submitted_at > 0) ? (acc << g.created_at - g.submission.submitted_at) : acc }
       next if time_diff.empty?


### PR DESCRIPTION
![lol](http://hosted.akibraun.com/g/167.gif)