### PR TITLE
Fix " undefined method 'level' for nil:NilClass "

### DIFF
--- a/app/models/user_course.rb
+++ b/app/models/user_course.rb
@@ -156,7 +156,7 @@ class UserCourse < ActiveRecord::Base
     self.exp = self.exp >= 0 ? self.exp : 0
 
     unless self.level
-      self.level = self.course.levels.find_by_level(0)
+      self.level = course.levels.first
     end
 
     new_level = self.course.levels.where("exp_threshold <=? ", self.exp ).last || self.level

--- a/lib/tasks/add_zero_level.rake
+++ b/lib/tasks/add_zero_level.rake
@@ -1,0 +1,11 @@
+namespace :db do
+  task add_zero_level: :environment do
+    courses = Course.all
+    courses.each do |course|
+      unless course.levels.find_by_level(0)
+        level = course.levels.build({ level: 0, exp_threshold: 0 })
+        level.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have two exceptions in the mail list:
"undefined method level for nil:NilClass"
"undefined method course for nil:NilClass"

All caused by that the host course doesn't have level 0.
so this line failed: <code> self.level = course.levels.find_by_level(0) </code> and <code> self.level </code> becomes <code>nil</code>

Fixed by:

added a <code>course.levels.first</code> to ensure self.level not to be nil.

A script to add zero level to all courses that don't have.

Need run <code> rake db:add_zero_level </code> on production server
