### PR TITLE
Let the students know their email addresses in enrollment invitations

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -132,6 +132,7 @@ class UserMailer < ActionMailer::Base
   end
 
   def enrollment_invitation(std_email, std_name, lecturer, course_title, redirect_url)
+    @email = std_email
     @user_name = std_name
     @lecturer = lecturer
     @course_title = course_title

--- a/app/views/user_mailer/enrollment_invitation.html.erb
+++ b/app/views/user_mailer/enrollment_invitation.html.erb
@@ -3,6 +3,8 @@ Dear <%= @user_name %>:
 <p>You are invited by <%= @lecturer %> to register for course: <%= @course_title %> on <b>Coursemology</b>.</p>
 <p><a href="<%= @redirect_url %>"> Click here</a> to accept the invitation.</p>
 
+<p>Please note that you should sign in with the email address <%= @email %>.</p>
+
 Best Regards,
 <br/>
 


### PR DESCRIPTION
Currently, Students might use the wrong email address to login after received the invitation email.

i.e. They use @u.nus.edu instead of @nus.edu.sg