### PR TITLE
build empty answers in grading new

### DIFF
--- a/app/controllers/assessment/gradings_controller.rb
+++ b/app/controllers/assessment/gradings_controller.rb
@@ -21,6 +21,8 @@ class Assessment::GradingsController < ApplicationController
       @summary[:qn_ans][q.id] = { qn: q.specific, i: i + 1 }
     end
 
+    @submission.build_initial_answers if @submission.assessment.questions.count != @submission.answers.count
+
     @submission.eval_answer
 
     @submission.answers.each do |ans|


### PR DESCRIPTION
Fix #351 #368 #370

If students submitted their missions, after that any new questions added to the mission will cause these exceptions. Because in the submitted missions, there is no answers for the the new question.

Fix this by build empty answers for those questions who don't have answers during grading.  It's a workaround, but as far as think it's the simplest way to solve these issues. 

And this is urgent I think. 