### PR TITLE
Sort Students in order in award exp page

### DIFF
--- a/app/controllers/manual_rewards_controller.rb
+++ b/app/controllers/manual_rewards_controller.rb
@@ -6,11 +6,11 @@ class ManualRewardsController < ApplicationController
     authorize! :award_points, UserCourse
 
     if params.has_key?(:all_students)
-      @student_courses = @course.user_courses.student
+      @student_courses = @course.student_courses_sorted_by_name
     else
       @student_courses = @course.tutorial_groups.where(tut_course_id:curr_user_course).map {|m| m.std_course}
       if !@student_courses
-        @student_courses = @course.user_courses.student
+        @student_courses = @course.student_courses_sorted_by_name
       end
     end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -82,6 +82,11 @@ class Course < ActiveRecord::Base
     self.user_courses.student
   end
 
+  # Return course students sorted by name irrespective of upper or lowercase
+  def student_courses_sorted_by_name
+    self.user_courses.student.sort_by! { |student| student.name.capitalize }
+  end
+
   def pending_gradings(curr_user_course)
     if curr_user_course.is_lecturer?
       submissions.mission_submissions.where(status:"submitted").order(:submitted_at)

--- a/spec/controllers/guilds_controller_spec.rb
+++ b/spec/controllers/guilds_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe GuildsController, :type => :controller do
-
-end

--- a/spec/factories/guild_users.rb
+++ b/spec/factories/guild_users.rb
@@ -1,6 +1,0 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
-FactoryGirl.define do
-  factory :guild_user do
-  end
-end

--- a/spec/factories/guilds.rb
+++ b/spec/factories/guilds.rb
@@ -1,8 +1,0 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
-FactoryGirl.define do
-  factory :guild do
-    name "MyString"
-    description "MyText"
-  end
-end

--- a/spec/features/manual_reward_pages_spec.rb
+++ b/spec/features/manual_reward_pages_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "ManualRewardPages", :type => :feature do
+  let(:user) { FactoryGirl.create(:lecturer) }
+  let(:student) { FactoryGirl.create(:student) }
+  let!(:course) { FactoryGirl.create(:course, creator: user) }
+  let!(:user_course) { FactoryGirl.create(:user_course, user: student, course: course) }
+
+  before do
+    sign_in user
+  end
+
+  describe "manual_exp page" do
+    before do
+      visit course_manual_exp_path(course)
+      expect(page).to have_link('View all students')
+      click_link('View all students')
+    end
+
+    it "shows student" do
+      expect(page).to have_content(student.name)
+    end
+    it "adds exp to student" do
+      find(:xpath, "//input[@name=\"exps[#{user_course.id}]\"]").set(100)
+      expect { click_button 'Give EXP' }.to change(ExpTransaction, :count).by(1)
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes #306 Sorts Students in order to allow manual awarding of EXP to be slightly easier.