### PR TITLE
Provide an option to prevent student from changing their name in courses

### DIFF
--- a/app/controllers/course_preferences_controller.rb
+++ b/app/controllers/course_preferences_controller.rb
@@ -30,6 +30,7 @@ class CoursePreferencesController < ApplicationController
         @preferences = @course.home_sections
         @no_preferences = @course.course_home_events_no_pref << @course.leaderboard_no_pef
         @achievement_pref = @course.achievements_locked_display
+        @user_course_pref = @course.user_course_change_name_pref
       when 'paging'
         @tab = 'PagingPreference'
         @preferences = @course.paging_prefs

--- a/app/controllers/user_courses_controller.rb
+++ b/app/controllers/user_courses_controller.rb
@@ -26,6 +26,7 @@ class UserCoursesController < ApplicationController
     end
     if params[:name]
       @user_course.user.name = params[:name].strip
+      @user_course.name = params[:name].strip
     end
     if params[:email]
       @user_course.user.email = params[:email].strip

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -278,6 +278,16 @@ class Course < ActiveRecord::Base
     self.course_preferences.join_items.item("Achievements").item_type('Icon').name('locked').first
   end
 
+  def user_course_change_name_pref
+    self.course_preferences.join_items.item("UserCourse").item_type('ChangeName').name('ChangeName').first
+  end
+
+  def allow_name_change?
+    # return true when there is no preference
+    pref = user_course_change_name_pref
+    pref.nil? || pref.display?
+  end
+
   def auto_create_sbm_pref
     self.course_preferences.join_items.item('Mission').item_type('Submission').name('auto').first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,7 +163,9 @@ class User < ActiveRecord::Base
   end
 
   def update_user_course
-    self.user_courses.each do |uc|
+    self.user_courses.includes(:course).each do |uc|
+      next unless uc.course.allow_name_change?
+
       uc.name = self.name
       uc.save
     end

--- a/app/views/course_preferences/_misc.html.erb
+++ b/app/views/course_preferences/_misc.html.erb
@@ -89,6 +89,20 @@
       </div>
     </div>
 
+    <% if @user_course_pref %>
+        <h3>Users</h3>
+        <p> Preference settings for users in course.</p>
+        <div class="info-block">
+          <div style="padding-left:5em" class="checkbox-text">
+            <input name="preferences[<%= @user_course_pref.id%>][prefer_value]"
+                   value="<%= @user_course_pref.prefer_value %>" type="hidden">
+            <input name="preferences[<%= @user_course_pref.id%>][display]"
+                   type="checkbox" <% if @user_course_pref.display? %> checked <% end %>>
+            <%= @user_course_pref.preferable_item.description %>
+          </div>
+        </div>
+    <% end %>
+
     <div class="center">
       <button class="btn btn-large btn-primary">Update</button>
     </div>

--- a/app/views/courses/manage_students.html.erb
+++ b/app/views/courses/manage_students.html.erb
@@ -35,7 +35,7 @@
                        html: { method: :put, class: "form-horizontal" }  do |f| %>
               <tr>
                 <td>
-                  <input type="text" name="name" value="<%= student.name %>" required>
+                  <input type="text" name="name" value="<%= student_course.name %>" required>
                 </td>
                 <td>
                   <input type="email" name="email" value="<%= student.email %>" required>

--- a/app/views/forums/forums/_forum.html.erb
+++ b/app/views/forums/forums/_forum.html.erb
@@ -24,7 +24,7 @@
     <span class="last_post">
     <% last_post = forum.last_post %>
       <% if last_post %>
-      <%= link_to last_post.topic.title, course_forum_topic_path(@course, forum, last_post.topic) -%> by <%= last_post.author ? last_post.author.user : '(unknown)' %>
+      <%= link_to last_post.topic.title, course_forum_topic_path(@course, forum, last_post.topic) -%> by <%= last_post.author ? last_post.author.name : '(unknown)' %>
           <time datetime="<%= last_post.created_at.to_s(:db) -%>"><%= time_ago_in_words(last_post.created_at) %> ago</time>
     <% else %>
       none

--- a/app/views/forums/posts/_post.html.erb
+++ b/app/views/forums/posts/_post.html.erb
@@ -3,7 +3,7 @@
   <div class="user">
     <% if post.author %>
       <h5 class="username">
-        <%= link_to post.author.user, course_user_course_path(@course, post.author) %>
+        <%= link_to post.author.name, course_user_course_path(@course, post.author) %>
       </h5>
       <div class="icon pull-right">
         <a href="<%= get_social_media_url(post.author) %>">

--- a/app/views/forums/posts/reply.html.erb
+++ b/app/views/forums/posts/reply.html.erb
@@ -6,7 +6,7 @@
     <div class="user">
       <% if @post.author %>
         <h5 class="username">
-          <%= link_to @post.author.user, course_user_course_path(@course, @post.author) %>
+          <%= link_to @post.author.name, course_user_course_path(@course, @post.author) %>
         </h5>
         <div class="icon pull-right">
           <img class="user-profile-pic" src="<%= @post.author.user.get_profile_photo_url %>"/>
@@ -21,7 +21,7 @@
 
       <% if @post.parent %>
         <div class="in-reply-to">
-          <%= link_to "In reply to #{@post.parent.author ? @post.parent.author.user : '(unknown)'}", "#post-#{@post.parent.id}" %>
+          <%= link_to "In reply to #{@post.parent.author ? @post.parent.author.name : '(unknown)'}", "#post-#{@post.parent.id}" %>
         </div>
       <% end %>
 

--- a/app/views/forums/topics/_topic.html.erb
+++ b/app/views/forums/topics/_topic.html.erb
@@ -22,7 +22,7 @@
     <div class="subject">
       <%= link_to topic.title, course_forum_topic_path(@course, @forum, topic) %>
     </div>
-    <div class="started-by">Started by <%= topic.author ? topic.author.user : '(unknown)' %></div>
+    <div class="started-by">Started by <%= topic.author ? topic.author.name : '(unknown)' %></div>
   </td>
   <td class="votes-count text-center"><%= topic.votes_count %></td>
   <td class="posts-count text-center"><%= topic.posts.count %></td>
@@ -30,7 +30,7 @@
   <td class="latest-post">
     <%  last_post = topic.posts.last %>
     <%  if last_post.author %>
-      <%= link_to last_post.author.user, course_user_course_path(@course, last_post.author) %><br />
+      <%= link_to last_post.author.name, course_user_course_path(@course, last_post.author) %><br />
     <% else %>
       (unknown)
     <% end %>

--- a/app/views/layouts/_course_side_bar.html.erb
+++ b/app/views/layouts/_course_side_bar.html.erb
@@ -10,7 +10,7 @@
         </a>
         <div id="user-profile-name">
           <a href="<%= main_app.course_user_course_path(@course, curr_user_course)%>">
-          <%= current_user.name %></a>
+          <%= curr_user_course.name %></a>
         </div>
         <div class="clearfix"></div>
       </div>

--- a/app/views/layouts/_user_thumb_profile.html.erb
+++ b/app/views/layouts/_user_thumb_profile.html.erb
@@ -3,7 +3,7 @@
   <img class="user-profile-pic" src="<%= user.get_profile_photo_url %>" />
 </a>
 <a href="<%= user_course.get_path %>">
-  <strong><%= user.name %></strong>
+  <strong><%= user_course.name %></strong>
 </a>
 
 <div class="clearfix"></div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -622,6 +622,15 @@ if PreferableItem.count == 64
 
 end
 
+if PreferableItem.count == 66
+  PreferableItem.create! item:             "UserCourse",
+                         item_type:        "ChangeName",
+                         name:             "ChangeName",
+                         default_value:    "",
+                         description:      "Allow students to change their names in course",
+                         default_display:  true
+end
+
 if NavbarLinkType.count == 0
   NavbarLinkType.create! link_type: 'module'
   NavbarLinkType.create! link_type: 'admin'

--- a/spec/features/course_specific_name_spec.rb
+++ b/spec/features/course_specific_name_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe 'Course specific name', type: :feature do
+  let!(:lecturer)           { FactoryGirl.create(:lecturer) }
+  let!(:student)            { FactoryGirl.create(:student) }
+  let!(:course)             { FactoryGirl.create(:course, :with_student, creator: lecturer, student: student) }
+  let!(:user_course)        { student.get_user_course(course) }
+
+  context 'when name change is allowed' do
+    before { Course.any_instance.stub(:allow_name_change?).and_return(true) }
+
+    context 'when change name in user profile' do
+      let(:new_name) { 'New Name' }
+
+      before do
+        sign_in student
+        visit users_settings_path
+        fill_in 'user_name', with: new_name
+        click_button 'Update'
+      end
+
+      it 'changes name in course' do
+        expect(user_course.reload.name).to eq new_name
+      end
+    end
+
+    context 'when change name in course' do
+      let(:new_name) { 'New Name' }
+
+      before do
+        sign_in lecturer
+        visit course_manage_students_path(course)
+        fill_in 'name', with: new_name
+        find(:xpath, '//button[@type="submit"]').click
+      end
+
+      it 'changes name in course' do
+        expect(user_course.reload.name).to eq new_name
+      end
+    end
+  end
+
+  context 'when name change is not allowed' do
+    before { Course.any_instance.stub(:allow_name_change?).and_return(false) }
+
+    context 'when change name in user profile' do
+      let(:new_name) { 'New Name' }
+
+      before do
+        sign_in student
+        visit users_settings_path
+        fill_in 'user_name', with: new_name
+        click_button 'Update'
+      end
+
+      it 'does not change name in course' do
+        expect(user_course.reload.name).not_to eq new_name
+      end
+    end
+
+    context 'when change name in course' do
+      let(:new_name) { 'New Name' }
+
+      before do
+        sign_in lecturer
+        visit course_manage_students_path(course)
+        fill_in 'name', with: new_name
+        find(:xpath, '//button[@type="submit"]').click
+      end
+
+      it 'changes name in course' do
+        expect(user_course.reload.name).to eq new_name
+      end
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Course, type: :model do
+  let!(:course) { FactoryGirl.create(:course) }
+
+  describe '#allow_name_change?' do
+    context 'when there is no preference' do
+      before { Course.any_instance.stub(:user_course_change_name_pref).and_return(nil) }
+
+      it 'returns true' do
+        expect(course.allow_name_change?).to eq true
+      end
+    end
+
+    context 'when disabled in preference' do
+      before { course.user_course_change_name_pref.update_column(:display, false) }
+
+      it 'returns false' do
+        expect(course.allow_name_change?).to eq false
+      end
+    end
+
+    context 'when enabled in preference' do
+      before { course.user_course_change_name_pref.update_column(:display, true) }
+
+      it 'returns true' do
+        expect(course.allow_name_change?).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This feature is required by Ben and some other teachers, basically they  don't want students to change their names in course.

We already have a name field in user course. When this option is disabled, after students changed their profile names, their names in specific course(i.e. <code>user_course.name</code>) will not be changed.

Changes in this PR:

1. option to allow/dis-allow students to change their names in course

2. use user_course.name instead of user.name in courses.


