### PR TITLE
Remove guild_user when after user_course is deleted

### DIFF
--- a/app/models/user_course.rb
+++ b/app/models/user_course.rb
@@ -41,7 +41,7 @@ class UserCourse < ActiveRecord::Base
   has_many :comment_subscriptions, dependent: :destroy
   has_many :comment_topics, through: :comment_subscriptions
 
-  has_one :guild_user
+  has_one :guild_user, dependent: :destroy
 
   #TODO
   # has_many :submissions, foreign_key: "std_course_id", dependent: :destroy


### PR DESCRIPTION
Currently <code>guild_user.user_course</code> will return <code>nil</code> and give exception when <code>user_course</code> is removed.