### PR TITLE
Make sure forums/topics are loaded under their parents' scope

### DIFF
--- a/app/controllers/forums/forums_controller.rb
+++ b/app/controllers/forums/forums_controller.rb
@@ -142,7 +142,7 @@ class Forums::ForumsController < ApplicationController
 
   private
   def load_forum
-    @forum = ForumForum.find_using_slug(params[:id] || params[:forum_id])
+    @forum = @course.forums.find_using_slug(params[:id] || params[:forum_id])
     if %w(new create).include?(params[:action])
       @forum = ForumForum.new
       @forum.assign_attributes(params[:forum])

--- a/app/controllers/forums/topics_controller.rb
+++ b/app/controllers/forums/topics_controller.rb
@@ -164,12 +164,11 @@ class Forums::TopicsController < ApplicationController
 
 private
   def load_forum
-    @forum = ForumForum.find_using_slug(params[:forum_id])
-    raise ActiveRecord::RecordNotFound unless @forum
+    @forum = @course.forums.find_using_slug!(params[:forum_id])
   end
 
   def load_topic
-    @topic = ForumTopic.find_using_slug(params[:id] || params[:topic_id])
+    @topic = @forum.topics.find_using_slug(params[:id] || params[:topic_id])
     if %w(new create).include?(params[:action])
       @topic = ForumTopic.new
       # No implicit assignment of attributes to the @post property. We need to create the post first before


### PR DESCRIPTION
This fixes a security issue that user can access other courses' forums / topics by changing the ids.