### PR TITLE
Auto-grading with keyword answers

### DIFF
--- a/app/assets/javascripts/general_question_auto_grading.js
+++ b/app/assets/javascripts/general_question_auto_grading.js
@@ -1,8 +1,17 @@
 
+function setAutoGradingKeywordMaxScore() {
+    var maxValue = $('#assessment_general_question_max_grade').val();
+    $('input[id^=assessment_general_question_auto_grading_keyword_options_attributes][id$=score]')
+        .attr({ 'max' : maxValue });
+}
+
 $(function () {
     $('input[name=assessment_general_question\\[auto_grading_type\\]]').change(function () {
         $('.auto-grading').removeClass('in');
         var autoGradingType = $(this).val();
         $('#auto-grading-' + autoGradingType).addClass('in');
     });
+
+    $('#assessment_general_question_max_grade')
+        .change(setAutoGradingKeywordMaxScore);
 });

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1118,6 +1118,15 @@ a.mission-box {
   content: "Auto-grading: exact match";
 }
 
+.auto-grading-keyword {
+  @extend  .grading-block;
+}
+
+.auto-grading-keyword:after {
+  @extend  .grading-block:after;
+  content: "Auto-grading: keywords";
+}
+
 a:hover, .leaderboard-achivement {
   text-decoration: none;
 }

--- a/app/helpers/assessment_helper.rb
+++ b/app/helpers/assessment_helper.rb
@@ -1,0 +1,12 @@
+module AssessmentHelper
+  # Given a string of text and a list of keywords, highlights each
+  # keyword occurrence with a <span> tag.
+  def highlight_keywords(original, keywords)
+    highlighted = original.dup
+    keywords.each do |keyword|
+      highlighted.gsub!(Regexp.new("\\b#{keyword}\\b"), content_tag(:mark, '\0').html_safe)
+    end
+    highlighted
+  end
+end
+

--- a/app/models/assessment/auto_grading_keyword_option.rb
+++ b/app/models/assessment/auto_grading_keyword_option.rb
@@ -1,0 +1,12 @@
+class Assessment::AutoGradingKeywordOption < ActiveRecord::Base
+  validates :keyword, format: {
+    with: /[\w\d]+/i,
+    message: "%{value} should be a single alphanumeric word."
+  }
+  validates :score, numericality: { greater_than_or_equal_to: 1 }
+
+  attr_accessible :general_question_id
+  attr_accessible :keyword, :score
+
+  belongs_to :general_question
+end

--- a/app/models/assessment/general_question.rb
+++ b/app/models/assessment/general_question.rb
@@ -9,7 +9,10 @@ class Assessment::GeneralQuestion < ActiveRecord::Base
   as_enum :auto_grading_type, none: 0, exact: 1, keyword: 2
 
   has_many :auto_grading_exact_options, dependent: :destroy, class_name: Assessment::AutoGradingExactOption.name
-
   attr_accessible :auto_grading_exact_options_attributes
   accepts_nested_attributes_for :auto_grading_exact_options, allow_destroy: true
+
+  has_many :auto_grading_keyword_options, dependent: :destroy, class_name: Assessment::AutoGradingKeywordOption.name
+  attr_accessible :auto_grading_keyword_options_attributes
+  accepts_nested_attributes_for :auto_grading_keyword_options, allow_destroy: true
 end

--- a/app/views/assessment/general_questions/_auto_grading_keyword_option_fields.html.erb
+++ b/app/views/assessment/general_questions/_auto_grading_keyword_option_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="nested-fields">
     <%= f.input :keyword, input_html: {rows: 4} %>
-    <%= f.input :score, input_html: {rows: 4, type: 'number'} %>
+    <%= f.input :score, input_html: {rows: 4, type: 'number', min: 1, onchange: 'setAutoGradingKeywordMaxScore()' } %>
 
     <div class="controls">
         <%= link_to_remove_association '<i class="icon-remove-sign"></i> Remove'.html_safe, f, class: "btn btn-warning btn-small", style: "display: inline" %>

--- a/app/views/assessment/general_questions/_auto_grading_keyword_option_fields.html.erb
+++ b/app/views/assessment/general_questions/_auto_grading_keyword_option_fields.html.erb
@@ -1,0 +1,10 @@
+<div class="nested-fields">
+    <%= f.input :keyword, input_html: {rows: 4} %>
+    <%= f.input :score, input_html: {rows: 4, type: 'number'} %>
+
+    <div class="controls">
+        <%= link_to_remove_association '<i class="icon-remove-sign"></i> Remove'.html_safe, f, class: "btn btn-warning btn-small", style: "display: inline" %>
+    </div>
+    <br />
+</div>
+

--- a/app/views/assessment/general_questions/_form.html.erb
+++ b/app/views/assessment/general_questions/_form.html.erb
@@ -29,6 +29,15 @@
         </div>
 
         <div id="auto-grading-keyword" class="auto-grading collapse <%= @question.auto_grading_type == :keyword ? 'in' : '' %>">
+            <% if @question.auto_grading_keyword_options.any? %>
+                <%= f.simple_fields_for :auto_grading_keyword_options do |option| %>
+                  <%= render partial: "auto_grading_keyword_option_fields",
+                             locals: { f: option } %>
+                <% end %>
+            <% end %>
+            <div class="links controls">
+              <%= link_to_add_association '<i class="icon-plus-sign"></i> Add Keyword Option'.html_safe, f, :auto_grading_keyword_options, html_options: { class: "btn btn-info" } %>
+            </div>
         </div>
     </div>
 

--- a/app/views/assessment/general_questions/_form.html.erb
+++ b/app/views/assessment/general_questions/_form.html.erb
@@ -36,7 +36,7 @@
                 <% end %>
             <% end %>
             <div class="links controls">
-              <%= link_to_add_association '<i class="icon-plus-sign"></i> Add Keyword Option'.html_safe, f, :auto_grading_keyword_options, html_options: { class: "btn btn-info" } %>
+              <%= link_to_add_association '<i class="icon-plus-sign"></i> Add Keyword Option'.html_safe, f, :auto_grading_keyword_options, class: "btn btn-info" %>
             </div>
         </div>
     </div>

--- a/app/views/assessment/gradings/_auto_grading_keyword_options.html.erb
+++ b/app/views/assessment/gradings/_auto_grading_keyword_options.html.erb
@@ -1,0 +1,16 @@
+<div class="auto-grading-keyword">
+  <table class="table table-striped table-bordered">
+    <thead>
+      <th>Keyword</th>
+      <th>Score</th>
+    </thead>
+    <tbody>
+      <% qn.auto_grading_keyword_options.each do |option| %>
+        <tr>
+          <td><%= option.keyword %></td>
+          <td><%= option.score %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/assessment/gradings/_multiple_question_form.html.erb
+++ b/app/views/assessment/gradings/_multiple_question_form.html.erb
@@ -63,8 +63,8 @@
               <div class="span10">
                 <% qn = qn_dic[:qn] %>
                 <% if qn.is_a? Assessment::GeneralQuestion %>
-                  <% if qn.auto_grading_type == :exact %>
-                    <%= render partial: 'assessment/gradings/auto_grading_exact_options', locals: {qn: qn} %>
+                  <% if qn.auto_grading_type != :none %>
+                    <%= render partial: "assessment/gradings/auto_grading_#{qn.auto_grading_type}_options", locals: {qn: qn} %>
                   <% end %>
                 <% end %>
                 <div class="grading-block">

--- a/app/views/assessment/gradings/_multiple_question_form.html.erb
+++ b/app/views/assessment/gradings/_multiple_question_form.html.erb
@@ -19,6 +19,7 @@
         </div>
         <h3>Answer:</h3>
         <% if qn_dic[:ans] %>
+          <% qn = qn_dic[:qn] %>
             <% if @assessment.specific.file_submission_only? %>
                 <p style="font-style: italic">Answer is contained in the submission file(s).</p>
             <% elsif qn_dic[:qn].class == Assessment::CodingQuestion %>
@@ -36,11 +37,17 @@
                                      edit_mode: (mode.to_s == 'edit') ? true : false
                                    } %>
             <% else %>
+              <% if qn.is_a?(Assessment::GeneralQuestion) %>
+                <% if qn.auto_grading_type == :keyword %>
+                  <%= highlight_keywords(qn_dic[:ans].content || "", qn.auto_grading_keyword_options.map(&:keyword)).html_safe %>
+                <% end %>
+              <% else %>
                 <div class="row-fluid">
                   <div class="submission-question-block span10">
                     <%= (qn_dic[:ans].content || "").html_safe %>
                   </div>
                 </div>
+              <% end %>
             <% end %>
             <input type="hidden" name="ags[<%= qn_dic[:grade].id if qn_dic[:grade] %>][answer_id]" value="<%= qn_dic[:ans].id %>">
             <% if @assessment.specific.comment_per_qn? && !@hide_comments%>

--- a/app/views/assessment/gradings/_single_question_form.html.erb
+++ b/app/views/assessment/gradings/_single_question_form.html.erb
@@ -47,8 +47,8 @@
         <div class="row-fluid">
           <div class="span10">
             <% if qn.is_a? Assessment::GeneralQuestion %>
-              <% if qn.auto_grading_type == :exact %>
-                <%= render partial: 'assessment/gradings/auto_grading_exact_options', locals: {qn: qn} %>
+              <% if qn.auto_grading_type != :none %>
+                <%= render partial: "assessment/gradings/auto_grading_#{qn.auto_grading_type}_options", locals: {qn: qn} %>
               <% end %>
             <% end %>
             <div class="grade-summary">

--- a/app/views/assessment/gradings/_single_question_form.html.erb
+++ b/app/views/assessment/gradings/_single_question_form.html.erb
@@ -22,7 +22,7 @@
                                 annotations:  qn_dic[:annotations],
                                 submission:   @submission,
                                 mode:         "view"} %>
-       <% elsif qn_dic[:qn].class == Assessment::ScribingQuestion %>
+        <% elsif qn_dic[:qn].class == Assessment::ScribingQuestion %>
             <%= render partial: 'assessment/mission_submissions/scribing_canvas',
                        locals: { question: qn_dic[:qn],
                                  qid: qid,
@@ -30,11 +30,17 @@
                                  edit_mode: (mode.to_s == 'edit') ? true : false
                                } %>
         <% else %>
+          <% if qn.is_a?(Assessment::GeneralQuestion) %>
+            <% if qn.auto_grading_type == :keyword %>
+              <%= highlight_keywords(qn_dic[:ans].content || "", qn.auto_grading_keyword_options.map(&:keyword)).html_safe %>
+            <% end %>
+          <% else %>
             <div class="row-fluid">
               <div class="submission-question-block span10">
                 <%= (qn_dic[:ans].content || "").html_safe %>
               </div>
             </div>
+          <% end %>
         <% end %>
         <input type="hidden" name="ags[<%= qn_dic[:grade].id if qn_dic[:grade] %>][answer_id]" value="<%= qn_dic[:ans].id %>">
         <!--show condition: new grading, review grading, update grading -->

--- a/app/views/assessment/missions/_form.html.erb
+++ b/app/views/assessment/missions/_form.html.erb
@@ -74,7 +74,7 @@
           <%= link_to_add_association '<i class="icon-plus-sign"></i> Add Dependency'.html_safe,
                                       f,
                                       :dependent_on,
-                                      html_options: { class: "btn btn-info" } %>
+                                      class: "btn btn-info" %>
         </div>
       </div>
     </div>

--- a/app/views/assessment/trainings/_form.html.erb
+++ b/app/views/assessment/trainings/_form.html.erb
@@ -33,7 +33,7 @@
           <%= link_to_add_association '<i class="icon-plus-sign"></i> Add Dependency'.html_safe,
                                       f,
                                       :dependent_on,
-                                      html_options: { class: "btn btn-info" } %>
+                                      class: "btn btn-info" %>
         </div>
       </div>
     </div>

--- a/db/migrate/20150702085119_create_auto_grading_keyword_options.rb
+++ b/db/migrate/20150702085119_create_auto_grading_keyword_options.rb
@@ -1,0 +1,9 @@
+class CreateAutoGradingKeywordOptions < ActiveRecord::Migration
+  def change
+    create_table :assessment_auto_grading_keyword_options do |t|
+      t.integer :general_question_id
+      t.string :keyword
+      t.integer :score
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150625085254) do
+ActiveRecord::Schema.define(:version => 20150702085119) do
 
   create_table "achievements", :force => true do |t|
     t.string   "icon_url"
@@ -204,6 +204,12 @@ ActiveRecord::Schema.define(:version => 20150625085254) do
     t.boolean "correct"
     t.text    "answer"
     t.text    "explanation"
+  end
+
+  create_table "assessment_auto_grading_keyword_options", :force => true do |t|
+    t.integer "general_question_id"
+    t.string  "keyword"
+    t.integer "score"
   end
 
   create_table "assessment_coding_answers", :force => true do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -157,6 +157,20 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_auto_graded_keyword_general_questions do
+      ignore do
+        creator { create(:lecturer) }
+        general_question_count 2
+      end
+      after(:build) do |mission, evaluator|
+        evaluator.general_question_count.times do
+          mission.questions << create(:general_question,
+                                      :auto_grading_keyword,
+                                      creator: evaluator.creator).question
+        end
+      end
+    end
+
     trait :with_coding_questions do
       ignore do
         creator { create(:lecturer) }
@@ -309,12 +323,30 @@ FactoryGirl.define do
         end
       end
     end
+
+    trait :auto_grading_keyword do
+      auto_graded true
+      auto_grading_type :keyword
+      ignore do
+        option_count 2
+      end
+      after(:build) do |question, evaluator|
+        evaluator.option_count.times do
+          question.auto_grading_keyword_options << build(:auto_grading_keyword_option)
+        end
+      end
+    end
   end
 
   factory :auto_grading_exact_option, class: Assessment::AutoGradingExactOption do
     correct true
     answer 'Some answer'
     explanation 'Some explanation'
+  end
+
+  factory :auto_grading_keyword_option, class: Assessment::AutoGradingKeywordOption do
+    keyword 'keyword1'
+    score 2
   end
 
   factory :coding_question, class: Assessment::CodingQuestion do

--- a/spec/features/general_auto_grading_spec.rb
+++ b/spec/features/general_auto_grading_spec.rb
@@ -1,26 +1,33 @@
 require 'rails_helper'
 
-describe "AutoGrading", :type => :feature do
+describe "AutoGrading", type: :feature do
   describe "Mission admin pages" do
     let!(:lecturer) { FactoryGirl.create(:lecturer) }
     let!(:course) { FactoryGirl.create(:course, creator: lecturer) }
     before do
       sign_in lecturer
+      visit new_course_assessment_submission_grading_path(course.id,
+                                                          mission.assessment.id,
+                                                          mission.submissions.first.id)
     end
 
     describe "exact options" do
       let!(:mission) do
         FactoryGirl.create(:mission, :with_auto_graded_exact_general_questions, :completed, course: course)
       end
-      before do
-        visit new_course_assessment_submission_grading_path(course.id,
-                                                            mission.assessment.id,
-                                                            mission.submissions.first.id)
-      end
-
       it 'should display the options' do
         expect(page).to have_text("Grading: #{mission.title}")
         expect(page).to have_selector('.auto-grading-exact', count: 2)
+      end
+    end
+
+    describe "keyword options" do
+      let!(:mission) do
+        FactoryGirl.create(:mission, :with_auto_graded_keyword_general_questions, :completed, course: course)
+      end
+      it 'should display the options' do
+        expect(page).to have_text("Grading: #{mission.title}")
+        expect(page).to have_selector('.auto-grading-keyword', count: 2)
       end
     end
   end


### PR DESCRIPTION
Implements feature 4 in Shuqun's feature requests. Depends on #427.

- On creating an assessment question, a UI for adding variable numbers of keyword-score pairs will be shown.
- When the question is graded, the keyword-score pairs for it are shown. The keywords will also be highlighted in the submitted solution, and a grade will be filled in based on how many keywords are present.