### PR TITLE
Assessment validations 

### DIFF
--- a/app/models/assessment/mission.rb
+++ b/app/models/assessment/mission.rb
@@ -12,9 +12,7 @@ class Assessment::Mission < ActiveRecord::Base
 
   validates_presence_of :title, :exp, :open_at, :close_at
 
-
-  #TODO
-  validates_with DateValidator, fields: [:open_at, :close_at]
+  validate :close_time_must_be_after_open_time
 
   def full_title
     "#{I18n.t('Assessment.Mission')} : #{self.title}"
@@ -38,6 +36,14 @@ class Assessment::Mission < ActiveRecord::Base
 
   def current_exp
     exp
+  end
+
+  private
+
+  def close_time_must_be_after_open_time
+    return unless close_at && open_at
+
+    errors[:close_at] << "must be after open at" if close_at < open_at
   end
 
 end

--- a/app/models/assessment/training.rb
+++ b/app/models/assessment/training.rb
@@ -13,8 +13,9 @@ class Assessment::Training < ActiveRecord::Base
   attr_accessible :dependent_on, :dependent_on_attributes
 
   validates_presence_of :title, :exp, :open_at
+  validates_numericality_of :bonus_exp
 
-  validates_with DateValidator, fields: [:open_at, :bonus_cutoff_at]
+  validate :bonus_cutoff_time_must_be_valid
 
   def full_title
     "#{I18n.t('Assessment.Training')} : #{self.title}"
@@ -22,5 +23,15 @@ class Assessment::Training < ActiveRecord::Base
 
   def get_path
     course_assessment_training_path(self.course, self)
+  end
+
+  private
+
+  def bonus_cutoff_time_must_be_valid
+    return if !bonus_exp || bonus_exp == 0
+
+    unless bonus_cutoff_at && bonus_cutoff_at > open_at
+      errors[:bonus_cutoff_at] << "must be after open time"
+    end
   end
 end

--- a/db/migrate/20150714051531_change_column_null_in_assessments.rb
+++ b/db/migrate/20150714051531_change_column_null_in_assessments.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNullInAssessments < ActiveRecord::Migration
+  def change
+    change_column_null :assessments, :as_assessment_id, false
+    change_column_null :assessments, :as_assessment_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150702085119) do
+ActiveRecord::Schema.define(:version => 20150714051531) do
 
   create_table "achievements", :force => true do |t|
     t.string   "icon_url"
@@ -360,8 +360,8 @@ ActiveRecord::Schema.define(:version => 20150702085119) do
   end
 
   create_table "assessments", :force => true do |t|
-    t.integer  "as_assessment_id"
-    t.string   "as_assessment_type"
+    t.integer  "as_assessment_id",                     :null => false
+    t.string   "as_assessment_type",                   :null => false
     t.integer  "course_id"
     t.integer  "creator_id"
     t.integer  "tab_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -67,6 +67,7 @@ FactoryGirl.define do
     title "Danger Room"
     description "Fight sentinels."
     exp 200
+    bonus_exp 0
     open_at Time.now
     bonus_cutoff_at Time.now
     published true


### PR DESCRIPTION
1. Redo the validations of bonus_exp and bonus_cutoff_at/close_at, which is not working properly now.

2. Add `null:false` constrain to `as_assesment`, we have a bug now that some assessments don't have the MTI child table.