### PR TITLE
Switched to HTTPS to avoid mixed content warning

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title>Coursemology</title>
   <!--[if lt IE 9]>
-  <script async src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script async src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/images/favicon.png">
@@ -54,7 +54,7 @@
 
   <%= render partial: "layouts/google_analytics" %>
   <%= render partial: "layouts/facebook_login" %>
-  <script async src='http://www.google.com/jsapi'></script>
+  <script async src='https://www.google.com/jsapi'></script>
 </head>
 <body>
 <div class="modal_loading"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title>Coursemology</title>
   <!--[if lt IE 9]>
-  <script async src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script async src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/images/favicon.png">
@@ -54,7 +54,7 @@
 
   <%= render partial: "layouts/google_analytics" %>
   <%= render partial: "layouts/facebook_login" %>
-  <script async src='https://www.google.com/jsapi'></script>
+  <script async src='http://www.google.com/jsapi'></script>
 </head>
 <body>
 <div class="modal_loading"></div>

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -206,6 +206,7 @@ namespace :db do
                                   creator_id: user.id,
                                   course_id: course.id,
                                   exp: rand(100) * 1000,
+                                  bonus_exp: 0,
                                   open_at: open_at,
                                   bonus_cutoff_at: bonus_cutoff_at}, :without_protection => true)
   end


### PR DESCRIPTION
I noticed that Firefox was issuing a mixed content warning on the edutech homepage (which seems to use Coursemology, though I'm not sure how the two codebases are related). I'm not actually sure where Google's JS API is used in Coursemology, but fixing the mixed content warning is simple enough. 

As an aside: Using the `async` attribute for MSIE < 9 is pretty pointless, because IE only started supporting `async` at v. 10+ - http://caniuse.com/#feat=script-async 